### PR TITLE
Fix systemd unit location

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cargo install clipboard-sync
 ```
 3. If you want it to run in the background, you can use tmux, or you can manually download the systemd service file and copy it to a systemd folder. You can download it to the correct path using this command, after which you may need to manually edit the file to point the correct binary location:
 ```bash
-wget -P "$HOME/.config/systemd/" https://raw.githubusercontent.com/dnut/clipboard-sync/master/clipboard-sync.service
+wget -P "$HOME/.config/systemd/user/" https://raw.githubusercontent.com/dnut/clipboard-sync/master/clipboard-sync.service
 ```
 It can be easily uninstalled:
 ```bash


### PR DESCRIPTION
Looks like the location for the systemd user unit in the readme is wrong.
According to https://wiki.archlinux.org/title/Systemd/User it should be in ~/.config/systemd/user/.
And that's working for me on openSUSE Tumbleweed.

PS: Thank you for your work. clipboard-sync is exactly what I needed after switching to wayland.
