### PR TITLE
Remove unnecessary unsafe

### DIFF
--- a/src/mustatex.rs
+++ b/src/mustatex.rs
@@ -7,20 +7,18 @@ macro_rules! mustatex {
 			$viz mod $name {
 				use super::*;
 
-				static mut INNER: std::sync::Mutex<$Type> = std::sync::Mutex::new($init);
+				static INNER: std::sync::Mutex<$Type> = std::sync::Mutex::new($init);
 
 				pub fn set(x: $Type) {
-					unsafe {
-						*INNER.lock().unwrap() = x;
-					}
+					*INNER.lock().unwrap() = x;
 				}
 
 				pub fn get() -> impl std::ops::Deref<Target = $Type> {
-					unsafe { INNER.lock().unwrap() }
+					INNER.lock().unwrap()
 				}
 
 				pub fn get_mut() -> impl std::ops::DerefMut<Target = $Type> {
-					unsafe { INNER.lock().unwrap() }
+					INNER.lock().unwrap()
 				}
 			}
 		)*


### PR DESCRIPTION
The static with the lock does not actually requires to be mutable, because of the mutex itself.